### PR TITLE
Fixing issues for IP address mapping and CSV output

### DIFF
--- a/show-configuration-interface-exporter.py
+++ b/show-configuration-interface-exporter.py
@@ -1,83 +1,69 @@
-import re
-import csv
+import csv # To write exported configuration to CSV
 
-global data
-global headers
-global output_file_location
+global output_file_location, output_file_name, subnet_masks, headers, data, interfaces, ip_addresses, mask_lengths, subnet_mask_list # Define Gloabl Variables
 
-
+# Define dictionary & lists the script will use
+#Definining subnet masks to map a mask length to a full legnth subnet mask
 subnet_masks = ['0.0.0.0','128.0.0.0','192.0.0.0','224.0.0.0','240.0.0.0','248.0.0.0','252.0.0.0','254.0.0.0','255.0.0.0','255.128.0.0','255.192.0.0','255.224.0.0','255.240.0.0','255.248.0.0','255.252.0.0','255.254.0.0','255.255.0.0','255.255.128.0','255.255.192.0','255.255.224.0','255.255.240.0','255.255.248.0','255.255.252.0','255.255.254.0','255.255.255.0','255.255.255.128','255.255.255.192','255.255.255.224','255.255.255.240','255.255.255.248','255.255.255.252','255.255.255.254','255.255.255.255']
-headers = ['Interface Name','IP Address','Subnet Mask','Mask Length']
-data = []
+headers = ['Interface Name','IP Address','Subnet Mask','Mask Length'] # CSV Headers
+data = [] # Data to write to the CSV file
+interfaces = [] # Interfaces detected from show configuration file
+ip_addresses = {} # IP addresses detected from show configuration file
+mask_lengths = [] # Interface mask lengths detected from show configuration file
+subnet_mask_list = [] # Subnet masks detected from show configuration file
 
-def interface_search(file_path):
-    x = 0
-    interfaces = []
-    ip_addresses = []
-    mask_lengths = []
-    subnet_mask_list = []
-    with open(file_path) as file: #Opens interface txt file
-        for line in file: #Searches every line in the file
-            if line.startswith('set interface '): #This line will catch any bonds that aren't consecutive with other bonds. E.g: bond5 & bond8.
+# Search for interfaces and add them to the interfaces list, also calls on the ip_address_mask_search function and the write_to_csv function
+def interface_search(file_path): 
+    x = 0 # Define x for use in writing an IP address to the ip_addresses dictionary
+    with open(file_path) as file: # Opens interface txt file
+        for line in file: # Searches every line in the file
+            if line.startswith('set interface '): # Checks the line starts with 'set interface'
                 keyword = 'interface'
-                before_keyword, keyword, after_keyword = line.partition(keyword) #This specifies all the contents of the line before the word bond, the word bond, and after the word bond.
-                interface = after_keyword.split(' ')#Updates bondnumber to match the current bond, so VLANs can be checked.
-                interface = str(interface[1])
-                ip_address_mask_search(line,interface,interfaces,subnet_masks,ip_addresses,mask_lengths,subnet_mask_list,x)
-        print(interfaces)
-        information = [interfaces,ip_addresses,mask_lengths,subnet_mask_list]
-        information = zip(*information)
-        write_to_csv(information)
+                before_keyword, keyword, after_keyword = line.partition(keyword) # This specifies all the contents of the line before, after and the word 'interface' itself.
+                interface = str(after_keyword.split(' ')[1]) # Splits the line after 'interface' at whitespace, then selects value [1] for the value of interface (this is because the interface name will follow the word interface)
+                if interface not in interfaces: # Check interface wasn't already added to interface list
+                    interfaces.append(interface) # Add interface to interface list
+                    ip_addresses[x] = ('N/A') # Insert 'N/A' to value x in ip_address dictionary (this gets overwritten later)
+                    mask_lengths.append('N/A') # Insert 'N/A'  to subnet mask list (gets overwritten later)
+                    subnet_mask_list.append('N/A') # Insert 'N/A'  to subnet mask list (gets overwritten later)
+                    x += 1
+    with open(file_path) as file: # Opens interface txt file
+        for line in file: # Searches every line in the file
+            ip_address_mask_search(line) # Run function to search for IP addresses within the file
+    ip_addresses_list = ip_addresses.values() # Once IP address search has run, convert dictionary into list for use in CSV file
+    information = [interfaces,ip_addresses_list,mask_lengths,subnet_mask_list] # Add all data columns to information list
+    information = zip(*information) # Zip information list to write to CSV
+    write_to_csv(information) # Call write_to_csv function
                 
             
 
-def ip_address_mask_search(line,interface,interfaces,subnet_masks,ip_addresses,mask_lengths,subnet_mask_list,x):
-    if interface not in interfaces and ' ipv4-address' in line:
-        before_ip_keyword, ip_keyword, after_ip_keyword = line.partition('ipv4-address')
-        ip_address = str(after_ip_keyword[:17].split(' ')[1])
-        ip_addresses.append(ip_address)
+def ip_address_mask_search(line):
+    if line.startswith ('set interface ') and 'ipv4-address' in line: # Check set interface <interface> ipv4-address is present in line
+        keyword = 'interface' # Split line to ensure an exact match (for example, without this when the code executres the following for loop, bond1 would match if bond1.1 was in the line)
+        before_keyword, keyword, after_keyword = line.partition(keyword)
+        interface = str(after_keyword.split(' ')[1])
+        for item in interfaces: # Iterate through interfaces to find which interface is in the line
+            if item == interface: # Check chosen interface exactly matches the interface in the line
+                x = interfaces.index(item) # Get the location of the interface in the interface list (so that the ipv4-address for the interface will be in the same index in the ipv4-address dictionary)
+                before_ip_keyword, ip_keyword, after_ip_keyword = line.partition('ipv4-address') # Split line to get the IP address
+                ip_address = str(after_ip_keyword[:17].split(' ')[1])
 
-        before_mask_keyword, mask_keyword, after_mask_keyword = line.partition('mask-length')
-        subnet_mask = int(after_mask_keyword[:3].split(' ')[1])
-        mask_lengths.append(subnet_mask)
-        subnet_mask_list.append(subnet_masks[subnet_mask])
-        subnet_mask = subnet_mask.strip()
-        #print(subnet_mask)
-        #write_to_csv(interfaces[x],ip_addresses[x],mask_lengths[x],subnet_mask_list[x])
-
-    elif interface not in interfaces:
-        ip_addresses.append('N/A')
-        mask_lengths.append('N/A')
-        subnet_mask_list.append('N/A')
-        interfaces.append(interface)
-        x = interfaces.index(interface)
-        #write_to_csv(interfaces[x],ip_addresses[x],mask_lengths[x],subnet_mask_list[x])
-    
-    elif interface in interfaces and ' ipv4-address' in line:
-        before_ip_keyword, ip_keyword, after_ip_keyword = line.partition('ipv4-address')
-        ip_address = str(after_ip_keyword[:17].split(' ')[1])
-        ip_addresses.insert(x, ip_address)
-
-        before_mask_keyword, mask_keyword, after_mask_keyword = line.partition('mask-length')
-        subnet_mask = int(after_mask_keyword[:3].split(' ')[1])
-        mask_lengths.insert(x , subnet_mask)
-        subnet_mask_list.insert(x, subnet_masks[subnet_mask])
-        #write_to_csv(interfaces[x],ip_addresses[x],mask_lengths[x],subnet_mask_list[x])
-
-    
-    return(interfaces,ip_addresses,mask_lengths,subnet_mask_list)
+                before_mask_keyword, mask_keyword, after_mask_keyword = line.partition('mask-length') # Split line to get the subnet mask
+                subnet_mask = int(after_mask_keyword[:3].split(' ')[1])
+                mask_lengths.insert(x , subnet_mask) # Add subnet mask to subnet mask CIDR notation list
+                subnet_mask_list.insert(x, subnet_masks[subnet_mask]) # Convert above CIDR notation to full length subnet mask
+                ip_addresses[x] = ip_address # Insert returned IP address to the same location in the ip_addresses dictionary
         
-def write_to_csv(information): #interface,ip_address,mask_length,subnet_mask
-    #information = [interface,ip_address,subnet_mask,mask_length]
+def write_to_csv(information): # Function to write information list to a CSV file
     data.append(information)
-    filename = (output_file_location+'ifconfig.csv')
-    with open(filename, 'w', newline='') as file:
-        csvwriter = csv.writer(file) # create a csvwriter object
-        csvwriter.writerow(headers) # write the header
-        for item in data:
-            csvwriter.writerow([item]) # write the rest of the data
+    with open(output_file_location, 'w', newline='') as csvfile: # Open CSV file in path specified by user input
+        csvwriter = csv.writer(csvfile, delimiter=',') # Create a csvwriter object
+        csvwriter.writerow(headers) # Write the header
+        csvwriter.writerows(information) # Write the rest of the data
         
-#input_file_location = input('Input file with full file path: ')
-#output_file_location = input('Desired file output file path (will be named ifconfig.csv): ')
-output_file_location = ''
-interface_search('showconfiguration.txt')
+input_file_location = input('Input file with full file path: ') # Get user input for input location
+output_file_location = input('Desired file output file path (including file name, with .csv extension): ') # Get user input for desired output file name and path
+if output_file_location[-4:] != '.csv': # Check user has given a .csv file for file output name and path
+    print('Please correct output file name to include .csv extension')
+    exit() # Exit code if .csv extension is not added
+interface_search(input_file_location) # Run interface search function


### PR DESCRIPTION
This was fixed by changing the IP address list to a dictionary, mapping the interface's IP address directly to the key corresponding key in the IP address dictionary.

The CSV output was fixed by updating from using writerow to writerows.